### PR TITLE
Fix: Remove page title

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,9 +14,10 @@
       text-align: center;
     }
 
-    h1 {
+    /* h1 element removed, so its style is no longer needed. */
+    /* h1 {
       font-size: 1.5rem;
-    }
+    } */
 
     button { /* General button styling */
       font-size: 1rem;
@@ -69,9 +70,10 @@
 
     /* Responsive adjustments */
     @media (max-width: 600px) {
-      h1 {
+      /* h1 element removed, so its style is no longer needed. */
+      /* h1 {
         font-size: 1.3rem; /* Slightly smaller heading on small screens */
-      }
+      } */
 
       #pdfControls {
         margin-bottom: 10px;
@@ -95,7 +97,6 @@
   </style>
 </head>
 <body>
-  <h1>Daily PDF Switcher</h1>
 
   <div id="pdfControls" style="margin-bottom: 10px;">
     <button id="prevPage">Previous Page</button>


### PR DESCRIPTION
I removed the H1 element containing the page title "Daily PDF Switcher" and commented out its associated CSS, as per your request.